### PR TITLE
Adding a "noMatch" result

### DIFF
--- a/lib/Classifier.js
+++ b/lib/Classifier.js
@@ -76,7 +76,7 @@ class Classifier {
             }
         });
 
-        return result;
+        return {result: result, value: max};
     }
 
 

--- a/lib/Classifier.js
+++ b/lib/Classifier.js
@@ -75,8 +75,10 @@ class Classifier {
                 max = current.value;
             }
         });
-
-        return {result: result, value: max};
+        if(max < 0.9){
+            result = "noMatch";
+        }
+        return result;
     }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,8 +26,14 @@ class NaturalSynaptic extends ClassifierBase {
         data.features = this.features;
 
         var payload = JSON.stringify(data);
-
-        fs.writeFile(filename, payload, callback);
+        if(!filename){
+            return payload;
+        }
+        else{
+            fs.writeFile(filename, payload, callback);
+            return payload;
+        }
+        
     };
 }
 


### PR DESCRIPTION
1- check my last commit for the context of this
2- the networks ouputs a string of value "noMatch" if it's not confident enough
3- the networks must return a value of 0.9 to be sure that it matches 
4- it blocks false positives
5- it might send false negatives but it just means that the networks need more training 
6- it's now a more useful module for chatbots maker, but it might not be your goal to make it a tool for them.

So that's your turn now.
Nice work BTW, this is the best NLP module that I found !